### PR TITLE
Avoid duplicated effects in LEDMode rotation

### DIFF
--- a/src/Kaleidoscope-LEDEffect-SolidColor.cpp
+++ b/src/Kaleidoscope-LEDEffect-SolidColor.cpp
@@ -4,7 +4,6 @@ LEDSolidColor::LEDSolidColor(uint8_t r, uint8_t g, uint8_t b) {
   this->r = r;
   this->g = g;
   this->b = b;
-  LEDControl.mode_add(this);
 }
 
 void


### PR DESCRIPTION
Before this commit, any SolidColor effects would appear in the LEDMode rotation twice (e.g. in the stock Model01-Firmware).  They would be added to the rotation both on construction and in Kaleidoscope.use().  This removes the duplication, and makes SolidColor effects behave similarly to other effects.